### PR TITLE
Add `example.py` and replace `MultiHeadNet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ python paper/benchmark.py --dataset ihdp --numruns 1000 --config paper/madnet_at
 python paper/benchmark.py --dataset bhp --numruns 200 --config paper/madnet_ade.yaml
 ```
 
+To run synthetic data example
+
+```shell
+python example/example.py
+```
+
 ## Semi-synthetic datasets
 
-### BHP - Gasoline demand data from Blundell et al. (2017).
+### BHP - Gasoline demand data from Blundell et al. (2017)
 
 This data is shared in this repo under the public domain licence described at the [Harvard dataverse.](https://dataverse.harvard.edu/dataset.xhtml;jsessionid=ab284f8afb3805aad6f8c6b9ddca?persistentId=doi%3A10.7910%2FDVN%2F0YALNP&version=&q=&fileTypeGroupFacet=%22Data%22&fileAccess=&fileTag=&fileSortField=&fileSortOrder=)
 

--- a/example/example.py
+++ b/example/example.py
@@ -1,0 +1,79 @@
+import jax
+from jax import Array
+from jax import random as jr
+
+from madnet.estimands import AverageTreatmentEffect
+from madnet.estimators import MADNet, RieszNet
+from madnet.logging import get_logger
+
+logger = get_logger(__name__)
+
+ATE = AverageTreatmentEffect()
+
+
+def synthetic_data(n, p, key: Array) -> tuple[Array, Array, Array]:
+    x_key, a_key, y_key = jr.split(key, 3)
+    x = jr.uniform(x_key, shape=(n, p))
+    propensity_score = jax.nn.sigmoid(x[:, 0] ** 2)
+    a = jr.binomial(a_key, 1, p=propensity_score, shape=(n,))
+    noise = jr.normal(y_key, shape=(n,))
+    cate = 0.1 + 0.05 * x[:, 0]
+    y = x[:, 0] - x[:, 1] + cate * a + noise
+    y = y.reshape((n, 1))
+    a = a.reshape((n, 1))
+    return y, a, x
+
+
+if __name__ == "__main__":
+    seed = 134
+    n = 4000
+    p = 6
+    num_epochs = 5000
+
+    key = jr.PRNGKey(seed)
+    key_train, key_estimation = jr.split(key)
+
+    y, a, x = synthetic_data(n=n, p=p, key=key_train)
+
+    rnet = RieszNet(
+        estimand=ATE,
+        covariate_dim=p,
+        key=key,
+    )
+    rnet_fitted, rnet_logs = rnet.fit(
+        a=a,
+        x=x,
+        y=y,
+        num_epochs=num_epochs,
+        key=key,
+        optimizer="adam",
+        min_delta=1e-6,
+        patience=40,
+    )
+    rnet_est = rnet_fitted.estimate(a=a, x=x, y=y)
+
+    # evaluate estimators
+    for name, vals in rnet_est.items():
+        logger.info(f"Estimator: {name}: {vals}")
+
+    # Repeat with MADNet
+    mnet = MADNet(
+        estimand=ATE,
+        covariate_dim=p,
+        key=key,
+    )
+    mnet_fitted, mnet_logs = mnet.fit(
+        a=a,
+        x=x,
+        y=y,
+        num_epochs=num_epochs,
+        key=key,
+        optimizer="adam",
+        min_delta=1e-6,
+        patience=40,
+    )
+    mnet_est = mnet_fitted.estimate(a=a, x=x, y=y)
+
+    # evaluate estimators
+    for name, vals in mnet_est.items():
+        logger.info(f"Estimator: {name}: {vals}")

--- a/madnet/estimators/_dragon.py
+++ b/madnet/estimators/_dragon.py
@@ -59,16 +59,15 @@ class DragonNet(BaseEstimator):
             regularization and mean squared error. Defaults to 0.1.
             key: A `jax.random.key`. Keyword Only.
         """
-        del nonshared_depth  # unused
         ate = AverageTreatmentEffect()
         super().__init__(estimand=ate)
         self.ps_weight = ps_weight
         self.target_reg = target_reg
-        self.mlp = eqx.nn.MLP(
+        self.mlp = MultiHeadMLP(
             in_size=covariate_dim,
             width_size=width_size,
-            depth=shared_depth,
-            out_size=3,
+            shared_depth=shared_depth,
+            nonshared_depths=(nonshared_depth, nonshared_depth, 0),
             activation=jax.nn.elu,
             key=key,
         )

--- a/madnet/estimators/_mad.py
+++ b/madnet/estimators/_mad.py
@@ -94,23 +94,22 @@ class MADNet(BaseEstimator):
             width_size: Neurons per layer. Defaults to 200.
             key: A `jax.random.key`. Keyword Only.
         """
-        del nonshared_depth  # unused
         super().__init__(estimand=estimand)
         if binary:
-            self.mlp = eqx.nn.MLP(
+            self.mlp = MultiHeadMLP(
                 in_size=covariate_dim + treatment_dim,
                 width_size=width_size,
-                depth=shared_depth,
-                out_size=3,
+                shared_depth=shared_depth,
+                nonshared_depths=(nonshared_depth, nonshared_depth, 0),
                 activation=jax.nn.elu,
                 key=key,
             )
         else:
-            self.mlp = eqx.nn.MLP(
+            self.mlp = MultiHeadMLP(
                 in_size=covariate_dim + treatment_dim,
                 width_size=width_size,
-                depth=shared_depth,
-                out_size=2,
+                shared_depth=shared_depth,
+                nonshared_depths=(nonshared_depth, 0),
                 activation=jax.nn.elu,
                 key=key,
             )

--- a/madnet/estimators/_riesz.py
+++ b/madnet/estimators/_riesz.py
@@ -63,25 +63,24 @@ class RieszNet(BaseEstimator):
             regularization and mean squared error. Defaults to 0.1.
             key: A `jax.random.key`. Keyword Only.
         """
-        del nonshared_depth  # unused
         super().__init__(estimand=estimand)
         self.rr_weight = rr_weight
         self.target_reg = target_reg
         if binary:
-            self.mlp = eqx.nn.MLP(
+            self.mlp = MultiHeadMLP(
                 in_size=covariate_dim + treatment_dim,
                 width_size=width_size,
-                depth=shared_depth,
-                out_size=3,
+                shared_depth=shared_depth,
+                nonshared_depths=(nonshared_depth, nonshared_depth, 0),
                 activation=jax.nn.elu,
                 key=key,
             )
         else:
-            self.mlp = eqx.nn.MLP(
+            self.mlp = MultiHeadMLP(
                 in_size=covariate_dim + treatment_dim,
                 width_size=width_size,
-                depth=shared_depth,
-                out_size=2,
+                shared_depth=shared_depth,
+                nonshared_depths=(nonshared_depth, 0),
                 activation=jax.nn.elu,
                 key=key,
             )


### PR DESCRIPTION
* As part of the ablation study, the Multiheaded architecture in several learners was replaced with an MLP.
* This PR resets the architectures to the intended Multiheaded
* A simple example script using synthetic data is added for users who want to apply these methods in practice